### PR TITLE
Explicit dropped variables

### DIFF
--- a/id/tree_test.go
+++ b/id/tree_test.go
@@ -58,7 +58,7 @@ func TestTree(t *testing.T) {
 			id := c4.Identify(bytes.NewReader([]byte{uint8(i)}))
 			digests[i] = id.Digest()
 		}
-		tree = c4.NewTree(digests)
+		_ = c4.NewTree(digests)
 	}
 
 }

--- a/id_test.go
+++ b/id_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
 	"sort"
 	"strconv"
 	"strings"

--- a/id_test.go
+++ b/id_test.go
@@ -64,8 +64,6 @@ func TestAll0000(t *testing.T) {
 	for i := 0; i < 64; i++ {
 		b = append(b, 0x00)
 	}
-	bignum := big.NewInt(0)
-	bignum = bignum.SetBytes(b)
 	var id c4.ID
 	copy(id[:], b)
 	if id.String() != `c41111111111111111111111111111111111111111111111111111111111111111111111111111111111111111` {

--- a/internals_test.go
+++ b/internals_test.go
@@ -73,7 +73,7 @@ func TestTree(t *testing.T) {
 			id := Identify(bytes.NewReader([]byte{uint8(i)}))
 			digests[i] = id
 		}
-		tree = NewTree(digests)
+		_ = NewTree(digests)
 	}
 
 }

--- a/store/logger_test.go
+++ b/store/logger_test.go
@@ -41,7 +41,7 @@ func TestLoggerStore(t *testing.T) {
 		t.Errorf("log output for Create does not match expected")
 	}
 	// Test Logger io.WriteCloser Write
-	n, err = w.Write([]byte(testdata))
+	_, err = w.Write([]byte(testdata))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestLoggerStore(t *testing.T) {
 		t.Errorf("log output for Read does not match expected")
 	}
 
-	n, err = f.Read(data2)
+	_, err = f.Read(data2)
 	if err != io.EOF {
 		t.Errorf("expected io.EOF, but got %v", err)
 	}


### PR DESCRIPTION
This PR takes a pass through a few packages and explicitly assigns unused variables to `"_"`. 